### PR TITLE
Add `rootDir` and other options also fixes the order the configs are loaded

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,17 +20,24 @@ function loadEnvironment(envPath) {
   }
 }
 
-function overrideCracoConfig({ cracoConfig, pluginOptions = {} }) {
-  const mode = getModeName()
+const defaultOptions = {
+  rootDir: process.cwd(),
+  mode: process.env.NODE_ENV,
+  variables: null,
+};
 
-  const basePath = path.resolve(process.cwd(), `.env${mode ? `.${mode}` : ''}`)
+function overrideCracoConfig({ cracoConfig, pluginOptions = {...defaultOptions} }) {
+  const options = {...defaultOptions, ...pluginOptions};
+  const mode = options.mode || getModeName();
+
+  const basePath = path.resolve(options.rootDir, `.env${mode ? `.${mode}` : ''}`)
   const localPath = `${basePath}.local`
 
   loadEnvironment(localPath)
   loadEnvironment(basePath)
 
-  if (pluginOptions.variables) {
-    const plugin = new webpack.EnvironmentPlugin(pluginOptions.variables)
+  if (options.variables) {
+    const plugin = new webpack.EnvironmentPlugin(options.variables)
 
     if (cracoConfig.webpack) {
       if (cracoConfig.webpack.plugins) {


### PR DESCRIPTION
Fixes #2

- Adds a `rootDir` option to specify where to start looking for `.env` files from. This is useful for monorepos
- Allow specifying other options which can be passed to [`dotenv`](https://github.com/motdotla/dotenv) itself
- Fix order in which the configs are loaded to match what CRA does (see https://create-react-app.dev/docs/adding-custom-environment-variables/#what-other-env-files-can-be-used)